### PR TITLE
Fix Overlapping Text in Tooltips

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -804,7 +804,7 @@ var Sprint;
     empty: function() {
       return this.each(function() {
         this.innerHTML = ""
-      }) 2oEie2SGGl
+      })
     },
     eq: function(index) {
       return Sprint(this.get(index))


### PR DESCRIPTION
Resolved a bug where tooltips displayed overlapping content on hover.